### PR TITLE
Use consult instead of reconsult

### DIFF
--- a/DQNSL/train.py
+++ b/DQNSL/train.py
@@ -204,9 +204,7 @@ if __name__ == '__main__':
             f.write(EgoFact)
             f.close()
 
-        # reconsult the prolog file to load clauses for finding safe actions
-        # you should add 'reconsult' command like 'consult' in pyswip file -> find prolog.py in pyswip installed directory
-        prolog.reconsult('prolog files/symbolic_logical_programming.pl')
+        prolog.consult('prolog files/symbolic_logical_programming.pl')
 
         # Action = list(prolog.query('safe_actions(Action)'))
         L = list(prolog.query('possible_actions(Actions)'))

--- a/README.md
+++ b/README.md
@@ -38,23 +38,12 @@ sudo apt install swi-prolog
 
 3- use `pip` to install the requirement packages from the `requirements.txt` file.
 
-4- you should make some changes to `PySwip` package:
-    
-+ if swi-prolog version is 9.0.4, then you should find `core.py` file in the virtual environment libraries (`lib`) and replace `PL_version` parameter with `PL_version_info`. 
-+ if swi-prolog version is older like 8.4.3, then skip this step.
-
-+ in `prolog.py` file, paste the following code in line 157:
-```    
-@classmethod 
-def reconsult(cls, filename, catcherrors=False):
-next(cls.query(filename.join(["reconsult('", "')"]), catcherrors=catcherrors))
-```
-5- clone the repository using the following command:
+4- clone the repository using the following command:
 ```
 git clone https://github.com/CAV-Research-Lab/Safe-Reinforcement-Learning-using-Symbolic-Logical-Programming-for-Autonomous-Highway-Driving.git
 ```
 
-6- run `train.py` in `DQN+SLP/` directory of the cloned repository to train the agent
+5- run `train.py` in `DQN+SLP/` directory of the cloned repository to train the agent
 
 ## Code development
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ openpyxl
 pygame
 pyswip
 torch
+scipy
+


### PR DESCRIPTION
Hello,

Thanks for using PySwip in your research.
Both the paper and the project look great!

This PR fixes a minor misconception about `reconsult`.
SWI-Prolog treats `consult` like `reconsult`, so the consulted file is always loaded.
Here is more about that from the SWI-Prolog docs:
https://www.swi-prolog.org/FAQ/reconsult.md

So, a modification to PySwip is not required.
I've updated the README and `train.py` to not use `reconsult`.

Also, it seems `scipy` is required to run the project.
I've added that to `requirements.txt`.

Hopefully these changes find their way to `main` :)